### PR TITLE
fix: set ssm path from process.env.NODE_ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Backend Starter repository
+# Canary Tests
 
 This repository contains the AWS canaries infrastrucure to roll-out a new synthetics health check or
 end to end test. 

--- a/src/synthetics/nodejs/node_modules/index.ts
+++ b/src/synthetics/nodejs/node_modules/index.ts
@@ -1,3 +1,5 @@
+import { config } from '../../../config';
+
 const synthetics = require('Synthetics');
 const aws = require('aws-sdk');
 
@@ -16,13 +18,13 @@ async function getPocketTestCredentials() {
   //TODO: we can read all secrets from a single parameter.
   //but JSON parsing doesn't work, so fetching them separately.
   let params = {
-    Name: `/CanaryTests/Dev/Canary/savedItems/pocketTestCredentials/accessToken`,
+    Name: `/CanaryTests/${config.environment}/Canary/savedItems/pocketTestCredentials/accessToken`,
     WithDecryption: true,
   };
   let a = await ssm.getParameter(params).promise();
   let accessKey = a.Parameter.Value;
   params = {
-    Name: `/CanaryTests/Dev/Canary/savedItems/pocketTestCredentials/consumerKey`,
+    Name: `/CanaryTests/${config.environment}/Canary/savedItems/pocketTestCredentials/consumerKey`,
     WithDecryption: true,
   };
   let c = await ssm.getParameter(params).promise();

--- a/src/synthetics/nodejs/node_modules/index.ts
+++ b/src/synthetics/nodejs/node_modules/index.ts
@@ -1,5 +1,3 @@
-import { config } from '../../../config';
-
 const synthetics = require('Synthetics');
 const aws = require('aws-sdk');
 
@@ -13,18 +11,22 @@ export const testConfig = {
 };
 
 async function getPocketTestCredentials() {
-  let ssm = new aws.SSM();
+  const isDev = process.env.NODE_ENV === 'development';
+  const environment = isDev ? 'Dev' : 'Prod';
+  console.log(`process.env.NODE_ENV: ${process.env.NODE_ENV}`);
+  console.log(`environment: ${environment}`);
 
+  let ssm = new aws.SSM();
   //TODO: we can read all secrets from a single parameter.
   //but JSON parsing doesn't work, so fetching them separately.
   let params = {
-    Name: `/CanaryTests/${config.environment}/Canary/savedItems/pocketTestCredentials/accessToken`,
+    Name: `/CanaryTests/${environment}/Canary/savedItems/pocketTestCredentials/accessToken`,
     WithDecryption: true,
   };
   let a = await ssm.getParameter(params).promise();
   let accessKey = a.Parameter.Value;
   params = {
-    Name: `/CanaryTests/${config.environment}/Canary/savedItems/pocketTestCredentials/consumerKey`,
+    Name: `/CanaryTests/${environment}/Canary/savedItems/pocketTestCredentials/consumerKey`,
     WithDecryption: true,
   };
   let c = await ssm.getParameter(params).promise();


### PR DESCRIPTION
set ssm path from env

this would work for `prod`, but will fail in dev. more detail in the comments. 